### PR TITLE
GPT-Based Text Span Annotations and TSNE Caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+#data folders
+datasets/
+output_data/
+
 # C extensions
 *.so
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+nltk
+scikit-learn
+ipympl
+ipywidgets
+matplotlib
+openai
+python-dotenv


### PR DESCRIPTION
This PR introduces the following updates:

1. **GPT-Based Text Span Annotations:**  
   - Integrated OpenAI API to generate stylistic text span annotations.  
   - Annotations are provided in a structured JSON format.  
   - In batch processing (`process_all_instances()`), annotations are saved as JSON files inside `output_data/` directory.  
   - For individual runs (e.g., for single instance in notebooks), the annotations are printed directly upon calling `demo.visualize_clusters()` instead of being saved. 

2. **TSNE Caching for Faster Visualization:**  
   - Implemented caching for TSNE computations to reduce processing time.  
   - Cache is stored as a pickle file for reuse.  

3. **Requirements File:**  
   - Added `requirements.txt` to manage dependencies such as OpenAI, scikit-learn, matplotlib, and pandas.  

## Known Issue
- The current implementation is reading cluster ids from the `hrs_explanations.json` file.  
- This should be updated to read clusters from the correct file: `luar_clusters_07`.  
- A fix will be made in a follow-up PR.  

## Next Steps
- Work on rendering and visualizing the highlights for the annotations.
