### PR TITLE
fixing the balance between g2v and llm featues

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,6 +1,6 @@
 # config.yaml
 instances_to_explain_path: "./datasets/hrs_explanations.json"
-interp_space_path:    "./datasets/luar_clusters_07/"
+interp_space_path:    "./datasets/luar_interp_space_cluster_09/"
 gram2vec_feats_path:      "./datasets/gram2vec_feats.csv"
 style_feat_clm:       "llm_tfidf_weights"
 top_k:                10

--- a/utils/visualizations.py
+++ b/utils/visualizations.py
@@ -166,8 +166,12 @@ def load_interp_space(cfg):
         #print('only gra2vec feats')
         dimension_to_style = {dim[0]:[feat for feat in dim[1] if feat in gram2vec_feats] for dim in dimension_to_style.items()}
 
-    # Take top features
-    dimension_to_style = {dim[0]: dim[1][:cfg['top_k']] for dim in dimension_to_style.items()}
+    # Take top features from g2v and llm
+    def take_to_k_llm_and_g2v_feats(feats_list, top_k):
+        g2v_feats = [x for x in feats_list if x in gram2vec_feats][:top_k]
+        llm_feats = [x for x in feats_list if x not in gram2vec_feats][:top_k]
+        return g2v_feats + llm_feats
+    dimension_to_style = {dim[0]: take_to_k_llm_and_g2v_feats(dim[1], cfg['top_k']) for dim in dimension_to_style.items()}
 
 
     return {


### PR DESCRIPTION
- I fixed the problem with cases where there are no LLM features.
- The problem was that we take the top_k overall the features and sometimes there will be few  or no LLM features in the top k
- Now the code take top k llm and top k gram2vec features as representation for every cluster