### PR TITLE
background author selection listener post zoom in & feature span not found bug 

### DIFF
--- a/app.py
+++ b/app.py
@@ -135,12 +135,80 @@ def app(share=False):
         # ── Visualization for clusters ─────────────────────────────
         gr.HTML(instruction_callout("Run visualization to see which author cluster contains the mystery document."))
         run_btn   = gr.Button("Run visualization")
+        bg_proj_state = gr.State()
+        bg_lbls_state = gr.State()
         with gr.Row():
             with gr.Column(scale=3):
-                plot_out   = gr.Plot(
+                # plot_out   = gr.Plot(
+                #     label="Cluster Visualization",
+                #     elem_id="cluster-plot"
+                # )
+                axis_ranges = gr.Textbox(visible=False, elem_id="axis-ranges")
+                plot = gr.Plot(
                     label="Cluster Visualization",
-                    elem_id="cluster-plot"
+                    elem_id="cluster-plot",
                 )
+                plot.change(
+                    fn=None,
+                    inputs=[plot],
+                    outputs=[axis_ranges],
+                    js="""
+                    function(){
+                        console.log("------------>[JS] plot.change() triggered<------------");
+
+                        let attempts = 0;
+                        const maxAttempts = 50;
+
+                        const tryAttach = () => {
+                            const gd = document.querySelector('#cluster-plot .js-plotly-plot');
+                            if (!gd) {
+                                if (++attempts < maxAttempts) {
+                                    requestAnimationFrame(tryAttach);
+                                } else {
+                                    console.error(" ------------>Could not find .js-plotly-plot after multiple attempts.<------------");
+                                }
+                                return;
+                            }
+
+                            if (gd.__zoomListenerAttached) {
+                                console.log("------------>Zoom listener already attached.<------------");
+                                return;
+                            }
+
+                            gd.__zoomListenerAttached = true;
+                            console.log("------------>Zoom listener attached!<------------");
+
+                            gd.on('plotly_relayout', (ev) => {
+                                if (
+                                    ev['xaxis.range[0]'] === undefined ||
+                                    ev['xaxis.range[1]'] === undefined ||
+                                    ev['yaxis.range[0]'] === undefined ||
+                                    ev['yaxis.range[1]'] === undefined
+                                ) return;
+
+                                const payload = {
+                                    xaxis: [ev['xaxis.range[0]'], ev['xaxis.range[1]']],
+                                    yaxis: [ev['yaxis.range[0]'], ev['yaxis.range[1]']]
+                                };
+
+                                const txtbox = document.querySelector('#axis-ranges textarea');
+                                if (txtbox) {
+                                    txtbox.value = JSON.stringify(payload);
+                                    txtbox.dispatchEvent(new Event('input', { bubbles: true }));
+                                    console.log("------------> Zoom payload dispatched:<------------", payload);
+                                } else {
+                                    console.warn("------------> No hidden textbox found to write zoom payload.<------------");
+                                }
+                            });
+                        };
+
+                        requestAnimationFrame(tryAttach);
+                        return '';
+                    }
+                    """
+                )
+
+
             with gr.Column(scale=1):
                 expl_html = """
                     <h4>What am I looking at?</h4>
@@ -155,6 +223,14 @@ def app(share=False):
                 """
                 gr.HTML(styled_html(expl_html))
         
+        # Add handler for filtered points
+        filtered_points = gr.Textbox(label="Filtered Points")  # Hidden component for filtered points
+        axis_ranges.change(
+            fn=handle_zoom, 
+            inputs=[axis_ranges, bg_proj_state, bg_lbls_state], 
+            outputs=[filtered_points]
+        )
+
         # ── Dynamic Cluster Choice dropdown ──────────────────────────────────
         gr.HTML(instruction_callout("Choose a cluster from the dropdown below to inspect whether its features appear in the mystery author’s text."))
         cluster_dropdown = gr.Dropdown(choices=[], label="Select Cluster to Inspect")
@@ -197,8 +273,11 @@ def app(share=False):
                 int(iid.replace('Task ','')), cfg, instances
             ),
             inputs=[task_dropdown],
-            outputs=[plot_out, cluster_dropdown, style_map_state]
+            outputs=[plot, cluster_dropdown, style_map_state, bg_proj_state, bg_lbls_state] #plot_out --> plot
         )
+        print(f"Visualizing complete.")
+        print(f"bg_labels = {bg_lbls_state.value}")
+        print(f" ......... \n\n")
 
         # When a cluster is selected, split features and populate radio buttons
         def on_cluster_change(selected_cluster, style_map):

--- a/app.py
+++ b/app.py
@@ -205,6 +205,8 @@ def app(share=False):
             cluster_key = extract_cluster_key(selected_cluster)
             all_feats = style_map[cluster_key]
             llm_feats, g2v_feats = split_features(all_feats)
+            # print(f"Selected cluster: {selected_cluster} ({cluster_key})")
+            # print(f"LLM features: {llm_feats}")
 
             # Add "None" as a default selectable option
             llm_feats = ["None"] + llm_feats
@@ -223,12 +225,13 @@ def app(share=False):
             return (
                 gr.update(choices=llm_feats, value=llm_feats[0]),
                 gr.update(choices=filtered_g2v, value=filtered_g2v[0]),
+                llm_feats
             )
 
         cluster_dropdown.change(
             fn=on_cluster_change,
             inputs=[cluster_dropdown, style_map_state],
-            outputs=[features_rb, gram2vec_rb]
+            outputs=[features_rb, gram2vec_rb , feature_list_state] #adding feature_list_state to persisit all llm features in the app state
         )
 
 
@@ -275,6 +278,10 @@ def app(share=False):
         combined_btn  = gr.Button("Show Combined Spans")
         combined_html = gr.HTML()
 
+        # print(f"in app: all_feats={feature_list_state.value}")
+        # print(f"in app: sel_feat_llm={features_rb.value}")
+
+
         combined_btn.click(
             fn=lambda iid, sel_feat_llm, all_feats, sel_feat_g2v: show_combined_spans_all(
                 client, iid.replace('Task ', ''), sel_feat_llm, all_feats, instances, sel_feat_g2v
@@ -282,6 +289,11 @@ def app(share=False):
             inputs=[task_dropdown, features_rb, feature_list_state, gram2vec_rb],
             outputs=[combined_html]
         )
+        # mapping -->
+        # iid = task_dropdown.value
+        # sel_feat_llm = features_rb.value
+        # all_feats = feature_list_state.value
+        # sel_feat_g2v = gram2vec_rb.value
 
     demo.launch(share=share)
 

--- a/app.py
+++ b/app.py
@@ -137,6 +137,7 @@ def app(share=False):
         run_btn   = gr.Button("Run visualization")
         bg_proj_state = gr.State()
         bg_lbls_state = gr.State()
+        bg_authors_df = gr.State()  # Holds the background authors DataFrame
         with gr.Row():
             with gr.Column(scale=3):
                 # plot_out   = gr.Plot(
@@ -227,7 +228,7 @@ def app(share=False):
         filtered_points = gr.Textbox(label="Filtered Points")  # Hidden component for filtered points
         axis_ranges.change(
             fn=handle_zoom, 
-            inputs=[axis_ranges, bg_proj_state, bg_lbls_state], 
+            inputs=[axis_ranges, bg_proj_state, bg_lbls_state, bg_authors_df], 
             outputs=[filtered_points]
         )
 
@@ -273,11 +274,8 @@ def app(share=False):
                 int(iid.replace('Task ','')), cfg, instances
             ),
             inputs=[task_dropdown],
-            outputs=[plot, cluster_dropdown, style_map_state, bg_proj_state, bg_lbls_state] #plot_out --> plot
+            outputs=[plot, cluster_dropdown, style_map_state, bg_proj_state, bg_lbls_state, bg_authors_df]
         )
-        print(f"Visualizing complete.")
-        print(f"bg_labels = {bg_lbls_state.value}")
-        print(f" ......... \n\n")
 
         # When a cluster is selected, split features and populate radio buttons
         def on_cluster_change(selected_cluster, style_map):

--- a/utils/gram2vec_feat_utils.py
+++ b/utils/gram2vec_feat_utils.py
@@ -118,6 +118,8 @@ def show_combined_spans_all(client, iid, selected_feature_llm, features_list, in
 
     # get llm spans map (list of spans objects) for each text
     if selected_feature_llm and selected_feature_llm != "None":
+        print(f"in show spans: Selected LLM feature: {selected_feature_llm}")
+        print(f"in show spans: features_list: {features_list}")
         llm_maps = [
         generate_feature_spans_cached(client, f"{iid}", texts[0][1], features_list, role="mystery"),
         generate_feature_spans_cached(client, f"{iid}_cand0",   texts[1][1], features_list, role="candidate"),
@@ -129,7 +131,7 @@ def show_combined_spans_all(client, iid, selected_feature_llm, features_list, in
             [
                 # positional: first arg → start_char, second → end_char
                 Span(txt.find(s), txt.find(s) + len(s))
-                for s in llm_maps[i].get(selected_feature_llm, [])
+                for s in llm_maps[i].get(selected_feature_llm) 
                 if s in txt
             ]
             for i, (_, txt) in enumerate(texts)


### PR DESCRIPTION
##  Feature: Zoom-based Author Selection & JS Event Handling

introduces support for interactive background author selection based on zoom events on the plot.

### Key Updates

- **Zoom Listener for Background Authors**
  - Implemented a JavaScript listener that detects plot zoom events and dispatches updated axis bounds to Python.
  - These bounds are used to filter the list of background authors (`bg_proj`) to identify which authors fall within the current view.
  - Currently displays matching `author_id`s and their associated `author_style_feats` in a textbox under the plot.

- **Debugging Support**
  - can verify listener attachment via browser DevTools → Console.
  - Logs like `"listener attached"` and `"payload dispatched"` confirm correct binding and event dispatch.

- **`handle_zoom()` Function Added**
  - Receives zoom payload, filters background authors, and returns author_id - feature list as output.
  - Includes JSON parsing error handling, and errors related to no visible authors in the area.

### Notes for Discussion

- Rendering long lists of features (especially when many authors are visible) might overwhelm the UI. Currently, all matched authors and features are dumped into the textbox. Let's discuss how we want to present this:
  - Paginated table? Scrollable pane? highlight only the most frequent features across all authors?
- No Gram2Vec features are available at the author level, so comparisons are not included.
- Open question: Should we **remove centroid-based feature analysis entirely**, or **support both** views (centroid and author-level) as toggle options?

---

## Bugfix: LLM Feature Span Detection Cache

- Resolved a bug where LLM-based features weren’t being correctly detected in the text due to stale cache hits.
- **Root cause:** Updating the feature list didn’t invalidate or bypass the cache, so OpenAI API calls were skipped even when required.
- **Fix:** `generate_feature_spans_cached()` in `llm_feat_utils.py` now uses a hash `{feature: "name_text", span: "span_text"}` per feature. If the hash is not found in the cache, it triggers a new OpenAI call.
- **Versioning:** Bump the cache version number (line 14 in `llm_feat_utils.py`) to force fresh cache generation when needed.
