### PR TITLE
updated feature highlight visualization

### DIFF
--- a/utils/llm_feat_utils.py
+++ b/utils/llm_feat_utils.py
@@ -11,7 +11,7 @@ _g2v_df      = pd.read_csv("datasets/gram2vec_feats.csv")
 GRAM2VEC_SET = set(_g2v_df['gram2vec_feats'].unique())
 
 # Bump this whenever there is a change prompt, feature space, etc...
-CACHE_VERSION = 1
+CACHE_VERSION = 2
 
 def _feat_hash(feature: str) -> str:
     blob = json.dumps({


### PR DESCRIPTION
- Introduced a `--use_cluster_feats` flag via argparse to toggle cluster-vs-zoom selection (just incase we want to use that implementation in the future).
-  By default, the `--use_cluster_feats` is set to `False`, `app.py` launches with select backgroud author view.
-  populating the `llm_feats` and `g2v_feats` from the `handle_zoom()` functionality
-  updated the llm_feats cache version to 2.
-  highlight working as expected.

