### PR TITLE
Patch for restoring missing Gram2Vec features

### DIFF
--- a/utils/augmented_human_readable.txt
+++ b/utils/augmented_human_readable.txt
@@ -352,3 +352,266 @@ Second person:Person=2
 Singular number:Number=Sing
 Superlative degree:Degree=Sup
 Third person:Person=3
+Number of Tokens:num_tokens
+
+Adjectival clause:acl
+Adjectival complement:acomp
+Adjectival modifier:amod
+Adverbial clause modifier:advcl
+Adverbial modifier:advmod
+Agent (in passive voice):agent
+Appositional modifier:appos
+Attribute:attr
+Case marking:case
+Clausal complement:ccomp
+Clausal subject:csubj
+Clausal subject (passive):csubjpass
+Complement of preposition:pcomp
+Compound word:compound
+Conjunct:conj
+Coordinating conjunction:cc
+Adposition (preposition or postposition):ADP
+Dative:dative
+Direct object:dobj
+Expletive:expl
+Marker (introducing adverbial clause):mark
+Meta modifier:meta
+Negation modifier:neg
+Nominal modifier:nmod
+Nominal subject (passive):nsubjpass
+Noun phrase as adverbial modifier:npadvmod
+Numeric modifier:nummod
+Object of preposition:pobj
+Object predicate:oprd
+Open clausal complement:xcomp
+Parataxis:parataxis
+Passive auxiliary:auxpass
+Possession modifier:poss
+Pre-correlative conjunction:preconj
+Predeterminer:predet
+Prepositional modifier:prep
+Quantifier modifier:quantmod
+Relative clause modifier:relcl
+Root of the sentence:ROOT
+Unspecified dependency:dep
+
+Article pronoun type:PronType=Art
+Bracket punctuation type:PunctType=Brck
+Cardinal number:NumType=Card
+Comma punctuation type:PunctType=Comm
+Comparative conjunction type:ConjType=Cmp
+Dash punctuation type:PunctType=Dash
+Demonstrative pronoun type:PronType=Dem
+Final punctuation:PunctSide=Fin
+Foreign word:Foreign=Yes
+Gerund verb form:VerbForm=Ger
+Hyphenated:Hyph=Yes
+Indefinite pronoun type:PronType=Ind
+Initial punctuation:PunctSide=Ini
+Modal verb type:VerbType=Mod
+Multiplicative number:NumType=Mult
+Negative polarity:Polarity=Neg
+Neuter gender:Gender=Neut
+Ordinal number:NumType=Ord
+Participle verb form:VerbForm=Part
+Period punctuation type:PunctType=Peri
+Possessive:Poss=Yes
+Quotation punctuation type:PunctType=Quot
+Reflexive:Reflex=Yes
+Relative pronoun type:PronType=Rel
+
+❤️:❤️
+👍:👍
+😂:😂
+😍:😍
+
+!:!
+":\\"
+%:%
+&:&
+':'
+(:(
+):\)
+*:*
+,:,
+-:-
+.:.
+;:;
+?:?
+_:_
+`:`
+–:–
+':'
+':'
+
+all-cleft:all-cleft
+coordinate-clause:coordinate-clause
+if-because-cleft:if-because-cleft
+it-cleft:it-cleft
+obj-relcl:obj-relcl
+passive:passive
+pseudo-cleft:pseudo-cleft
+subj-relcl:subj-relcl
+tag-question:tag-question
+there-cleft:there-cleft
+
+punctuation:punctuation
+
+Articles:DET
+Auxiliary Verbs:AUX
+Conjunctions:CCONJ
+Prepositions:ADP
+
+Personal Pronouns:category:Personal Pronouns
+Demonstrative Pronouns:category:Demonstrative Pronouns
+Interrogative Pronouns:category:Interrogative Pronouns
+Modal Verbs:category:Modal Verbs
+Contractions:category:Contractions
+Adverbs:category:Adverbs
+Other:category:Other
+
+i:i
+me:me
+my:my
+myself:myself
+we:we
+our:our
+ours:ours
+ourselves:ourselves
+you:you
+'re:'re
+'ve:'ve
+'ll:'ll
+'d:'d
+'s:'s
+'t:'t
+your:your
+yours:yours
+yourself:yourself
+yourselves:yourselves
+he:he
+him:him
+his:his
+himself:himself
+she:she
+her:her
+ers:ers
+herself:herself
+it:it
+its:its
+itself:itself
+they:they
+them:them
+their:their
+theirs:theirs
+themselves:themselves
+what:what
+which:which
+who:who
+this:this
+that:that
+these:these
+those:those
+am:am
+is:is
+are:are
+was:was
+were:were
+be:be
+been:been
+being:being
+have:have
+has:has
+had:had
+having:having
+do:do
+does:does
+did:did
+doing:doing
+a:a
+an:an
+the:the
+and:and
+but:but
+if:if
+or:or
+because:because
+as:as
+until:until
+while:while
+of:of
+at:at
+by:by
+for:for
+with:with
+about:about
+against:against
+between:between
+into:into
+through:through
+during:during
+before:before
+after:after
+above:above
+below:below
+to:to
+from:from
+up:up
+down:down
+in:in
+out:out
+on:on
+off:off
+over:over
+under:under
+again:again
+further:further
+then:then
+once:once
+here:here
+there:there
+when:when
+where:where
+why:why
+how:how
+all:all
+any:any
+both:both
+each:each
+few:few
+more:more
+most:most
+other:other
+some:some
+such:such
+no:no
+nor:nor
+not:not
+only:only
+own:own
+same:same
+so:so
+than:than
+too:too
+very:very
+can:can
+will:will
+just:just
+don:don
+should:should
+now:now
+ain:ain
+aren:aren
+couldn:couldn
+didn:didn
+doesn:doesn
+hadn:hadn
+hasn:hasn
+haven:haven
+isn:isn
+ma:ma
+shouldn:shouldn
+wasn:wasn
+weren:weren
+won:won
+wouldn:wouldn

--- a/utils/gram2vec_feat_utils.py
+++ b/utils/gram2vec_feat_utils.py
@@ -19,9 +19,10 @@ FEATURE_HANDLERS = {
     "Punctuation":            "punctuation",
     "Letter":                 "letters",
     "Dependency Label":       "dep_labels",
-    "Morphology Tag":      "morph_tags",
+    "Morphology Tag":         "morph_tags",
     "Sentence Type":          "sentences",
-    "Emoji":                  "emojis"
+    "Emoji":                  "emojis",
+    "Number of Tokens":       "num_tokens"
 }
 
 @lru_cache(maxsize=1)
@@ -54,6 +55,30 @@ def get_shorthand(feature_str: str) -> str:
         return None  # fallback to the human-readable name
     return f"{FEATURE_HANDLERS[category]}:{code}"
 
+def get_fullform(shorthand: str) -> str:
+    """
+    Expects 'prefix:code' (e.g., 'pos_unigrams:ADJ'), returns 'Category:Human-Readable' 
+    (e.g., 'Part-of-Speech Unigram:Adjective'), or None if invalid.
+    """
+    try:
+        prefix, code = shorthand.split(":", 1)
+    except ValueError:
+        return None
+
+    # Reverse FEATURE_HANDLERS
+    reverse_handlers = {v: k for k, v in FEATURE_HANDLERS.items()}
+    category = reverse_handlers.get(prefix)
+    if category is None:
+        return None
+
+    # Reverse code map
+    code_map = load_code_map()
+    reverse_code_map = {v: k for k, v in code_map.items()}
+    human = reverse_code_map.get(code)
+    if human is None:
+        return None
+
+    return f"{category}:{human}"
 
 def highlight_both_spans(text, llm_spans, gram_spans):
     """

--- a/utils/ui.py
+++ b/utils/ui.py
@@ -128,6 +128,7 @@ def update_task_display(mode, iid, instances, background_df, mystery_file, cand1
     # computing g2v features
     print("Generating g2v features for on background corpus")
     background_df, task_authors_df = compute_g2v_features(background_df, task_authors_df)
+    print(f"Gram2Vec feature generation complete")
 
     # except Exception as e:
     #     print(f"Embedding generation failed: {e}")

--- a/utils/visualizations.py
+++ b/utils/visualizations.py
@@ -12,7 +12,7 @@ from gradio import update
 import re
 from utils.interp_space_utils import compute_clusters_style_representation, compute_clusters_g2v_representation
 from utils.llm_feat_utils import split_features
-from utils.gram2vec_feat_utils import get_shorthand
+from utils.gram2vec_feat_utils import get_shorthand, get_fullform
 
 import plotly.io as pio
 
@@ -242,26 +242,28 @@ def handle_zoom(event_json, bg_proj, bg_lbls, clustered_authors_df, task_authors
         other_author_ids=[],
         features_clm_name='g2v_vector'
     )
-    
-    # Filter out any Gram2Vec feature without a shorthand
-    filtered_g2v = []
+
+    # Gram2vec features are already in shorthand. convert to human readable for display
+    HR_g2v_list = []
     for feat in g2v_feats:
-        if get_shorthand(feat) is None:
-            print(f"Skipping Gram2Vec feature without shorthand: {feat}")
+        HR_g2v = get_fullform(feat)
+        print(f"\n\n feat: {feat} ---> Human Readable: {HR_g2v}")
+        if HR_g2v is None:
+            print(f"Skipping Gram2Vec feature without human readable form: {feat}")
         else:
-            filtered_g2v.append(feat)
-    
-    # Add "None" as a default selectable option
-    filtered_g2v = ["None"] + filtered_g2v
+            HR_g2v_list.append(HR_g2v)
+
+    HR_g2v_list = ["None"] + HR_g2v_list
 
     print(f"[INFO] Found {len(llm_feats)} LLM features and {len(g2v_feats)} Gram2Vec features in the zoomed region.")   
+    print(f"[INFO] unfiltered g2v features: {g2v_feats}")
 
     print(f"[INFO] LLM features: {llm_feats}")
-    print(f"[INFO] Gram2Vec features: {filtered_g2v}")
+    print(f"[INFO] Gram2Vec features: {HR_g2v_list}")
 
     return (
         gr.update(choices=llm_feats, value=llm_feats[0]),
-        gr.update(choices=filtered_g2v, value=filtered_g2v[0]),
+        gr.update(choices=HR_g2v_list, value=HR_g2v_list[0]), 
         llm_feats
     )
     # return gr.update(value="\n".join(llm_feats).join("\n").join(g2v_feats)), llm_feats, g2v_feats


### PR DESCRIPTION
PR resolves the issue where Gram2Vec features computed on-the-fly were being unintentionally filtered out. 

These features were already in shorthand format (e.g., `pos_unigrams:ADJ`), while the filtering logic expected human-readable fullforms (e.g., `Part-of-Speech Unigram:Adjective`) (similar to ones originally saved in the HRS/luar clusters dataset), leading to no matches and all features being skipped.

### Changes made:
- Added a reverse mapping from shorthand → fullform (`get_fullform()` in `utils/gram2vec_feat_utils.py`)
- Applied this conversion before the filtering step (inside `handle_zoom()` in `utils/visualizations.py`)
- the span generation code also expects human readable full forms, therefore this change maintains continued downstream compatibility (Tested and it seems to be working fine). 
- Also updated the `utils/augmented_human_readable.txt` based on the mapping Peter had shared
